### PR TITLE
Filter templates

### DIFF
--- a/view/app/.meteor/packages
+++ b/view/app/.meteor/packages
@@ -42,3 +42,4 @@ bevanhunt:leaflet
 practicalmeteor:mocha
 dispatch:mocha
 mdg:validated-method
+aldeed:template-extension

--- a/view/app/.meteor/versions
+++ b/view/app/.meteor/versions
@@ -8,6 +8,7 @@ aldeed:collection2-core@1.2.0
 aldeed:schema-deny@1.1.0
 aldeed:schema-index@1.1.1
 aldeed:simple-schema@1.5.3
+aldeed:template-extension@4.1.0
 allow-deny@1.0.5
 autoupdate@1.2.11
 babel-compiler@6.13.0

--- a/view/app/imports/api/boxEvent/BoxEventCollection.js
+++ b/view/app/imports/api/boxEvent/BoxEventCollection.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import BaseCollection from '../base/BaseCollection.js';
+import { check, Match } from 'meteor/check';
 
 class BoxEventCollection extends BaseCollection {
 
@@ -23,7 +24,8 @@ class BoxEventCollection extends BaseCollection {
     this.publicationNames = {
       RECENT_BOX_EVENTS: 'recent_box_events',
       COMPLETE_RECENT_BOX_EVENTS: 'complete_recent_box_events',
-      DAILY_BOX_EVENTS: 'daily_box_events'
+      DAILY_BOX_EVENTS: 'daily_box_events',
+      GET_BOX_EVENTS: 'get_box_events'
     };
   }
 
@@ -38,6 +40,22 @@ class BoxEventCollection extends BaseCollection {
       boxEventPublications();
     }
   }
+
+  queryConstructors() {
+    return {
+      getBoxEvents({startTime, endTime}) {
+        check(startTime, Date);
+        check(endTime, Match.Maybe(Date)); // Optional
+
+        // Null or undefined endTime indicates we want all events > startTime
+        const selector = (!endTime) ? {eventStart: {$gte: new Date(startTime)}}
+                                    : {eventStart: {$gte: new Date(startTime)}, eventEnd: {$lte: new Date(endTime)}};
+
+        return selector;
+      }
+    }
+  }
+
 }
 
 /**
@@ -45,3 +63,12 @@ class BoxEventCollection extends BaseCollection {
  * @type {BoxEventCollection}
  */
 export const BoxEvents = new BoxEventCollection();
+
+Meteor.startup(() => {
+  if (Meteor.isServer) {
+    // BoxEvents._collection._ensureIndex({eventStart: -1, eventEnd: -1});
+    // BoxEvents._collection._ensureIndex({eventStart: -1});
+    // BoxEvents._collection._ensureIndex({eventEnd: -1});
+  }
+
+});

--- a/view/app/imports/api/boxEvent/BoxEventCollectionMethods.js
+++ b/view/app/imports/api/boxEvent/BoxEventCollectionMethods.js
@@ -1,0 +1,42 @@
+import { ValidatedMethod } from 'meteor/mdg:validated-method';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { BoxEvents } from './BoxEventCollection.js';
+import Moment from 'moment';
+import { demapify } from 'es6-mapify';
+import { timeUnitString } from "../../utils/utils.js";
+
+export const boxEventsCount = new ValidatedMethod({
+  name: 'BoxEvents.BoxEventsCount',
+  validate: new SimpleSchema({
+    startTime: {type: Date},
+    endTime: {type: Date, optional: true}
+  }).validator({clean: true}),
+  run({ startTime, endTime}) {
+    const selector = BoxEvents.queryConstructors().getBoxEvents({ startTime, endTime });
+    const boxEvents = BoxEvents.find(selector, {});
+    return boxEvents.count();
+  }
+});
+
+export const boxEventsCountMap = new ValidatedMethod({
+  name: 'BoxEvents.BoxEventsCountMap',
+  validate: new SimpleSchema({
+    timeUnit: {type: String},
+    startTime: {type: Date},
+    endTime: {type: Date, optional: true}
+  }).validator({clean: true}),
+  run({ timeUnit, startTime, endTime}) {
+    // TimeUnits can be year, month, week, day, dayOfMonth, hourOfDay
+    const selector = BoxEvents.queryConstructors().getBoxEvents({ startTime, endTime });
+    const boxEvents = BoxEvents.find(selector, {});
+
+    const boxEventsCountMap = new Map();
+    boxEvents.forEach(event => {
+      const timeUnitKey = timeUnitString(event.eventStart, timeUnit);
+      (boxEventsCountMap.has(timeUnitKey)) ? boxEventsCountMap.set(timeUnitKey, boxEventsCountMap.get(timeUnitKey) + 1)
+                                           : boxEventsCountMap.set(timeUnitKey, 1);
+    });
+
+    return demapify(boxEventsCountMap);
+  }
+});

--- a/view/app/imports/api/boxEvent/BoxEventCollectionPublications.js
+++ b/view/app/imports/api/boxEvent/BoxEventCollectionPublications.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { BoxEvents } from './BoxEventCollection.js';
 import { EventData } from '../eventData/EventDataCollection.js';
+import { check, Match } from 'meteor/check';
 
 export const boxEventCollectionPublications = () => {
   Meteor.publish(BoxEvents.publicationNames.RECENT_BOX_EVENTS, function (numRecentEvents) {
@@ -30,5 +31,15 @@ export const boxEventCollectionPublications = () => {
     const paginatedRequestIds = requestIds.slice(0, numRecentEvents);
 
     return BoxEvents.find({reqId: {$in: paginatedRequestIds}}, {});
+  });
+
+  Meteor.publish(BoxEvents.publicationNames.GET_BOX_EVENTS, function({startTime, endTime}) {
+    check(startTime, Match.OneOf(Date, Number));
+    check(endTime, Match.OneOf(Date, Number, null, undefined));
+
+    const selector = BoxEvents.queryConstructors().getBoxEvents({startTime, endTime});
+    const events = BoxEvents.find(selector, {});
+
+    return events;
   });
 };

--- a/view/app/imports/api/boxEvent/boxEventsPublications.js
+++ b/view/app/imports/api/boxEvent/boxEventsPublications.js
@@ -1,9 +1,0 @@
-import { Meteor } from 'meteor/meteor';
-import BoxEvents from './boxEvents.js';
-
-Meteor.publish('boxEvents', function(startTimeSecondsAgo) {
-  const startTimeMs = Date.now() - (startTimeSecondsAgo * 1000);
-  const events = BoxEvents.find({eventStart: {$gte: startTimeMs}});
-
-  return events;
-});

--- a/view/app/imports/api/boxEvent/index.js
+++ b/view/app/imports/api/boxEvent/index.js
@@ -1,1 +1,2 @@
 import './BoxEventCollection.js';
+import './BoxEventCollectionMethods.js';

--- a/view/app/imports/startup/client/index.js
+++ b/view/app/imports/startup/client/index.js
@@ -6,7 +6,20 @@ import '../../ui/stylesheets/site.css';
 
 // Component Templates
 import '../../ui/components/flashMessage/flashMessage.js';
+import '../../ui/components/form-controls/input-label-block-helper.html';
 
 // Get rid of the default __blaze-root div element and use the regular <body> element instead.
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 BlazeLayout.setRoot('body');
+
+// Blaze Views already have an isRendered property associated with each view, however it is not a reactive property.
+// By attaching a new _isRendered ReactiveVar to each template, we now have a useful way to reactively detect when
+// a template has been rendered.
+Template.onCreated(function globalOnCreated() {
+  const template = this;
+  template._isRendered = new ReactiveVar(false);
+});
+Template.onRendered(function globalOnRendered(){
+  const template = this;
+  template._isRendered.set(true);
+});

--- a/view/app/imports/ui/components/eventCountChart/eventCountChart.js
+++ b/view/app/imports/ui/components/eventCountChart/eventCountChart.js
@@ -3,19 +3,38 @@ import { BoxEvents } from '../../../api/boxEvent/BoxEventCollection.js';
 import Chartjs from 'chart.js';
 import Moment from 'moment';
 import { Random } from 'meteor/random';
+import { filterFormSchema } from "../../../utils/schemas.js";
 
 // Templates and Sub-Template Inclusions
 import './eventCountChart.html';
+import { dataContextValidator } from "../../../utils/utils.js";
 
 
 Template.eventCountChart.onCreated(function () {
   const template = this;
 
-  template.eventCountChart = null;
+  dataContextValidator(template, new SimpleSchema({
+    filters: {type: filterFormSchema, optional: true} // Optional because data context not available immediately.
+  }), null);
 
-  // Subscriptions
+  template.eventCountChart = null;
+  template.currentDay = new ReactiveVar();
+
+  // Set currentDay reactive var.
   template.autorun(() => {
-    template.subscribe(BoxEvents.publicationNames.DAILY_BOX_EVENTS);
+    const dataContext = Template.currentData();
+    (dataContext && dataContext.filters) ? template.currentDay.set(dataContext.filters.dayPicker)
+                                         : template.currentDay.set(new Date());
+  });
+
+  // Subscription
+  template.autorun(() => {
+    const currentDay = template.currentDay.get();
+    if (currentDay) {
+      const startOfDay = Moment(currentDay).startOf('day').toDate(); // Ensure selected day is start of day timestamp.
+      const endOfDay = Moment(currentDay).endOf('day').toDate();
+      template.subscribe(BoxEvents.publicationNames.GET_BOX_EVENTS, {startTime: startOfDay, endTime: endOfDay});
+    }
   });
 });
 
@@ -25,81 +44,80 @@ Template.eventCountChart.onRendered(function () {
   // Chart to display recent event counts by device id. Group into hours, max 24 hours.
   template.autorun(() => {
     // Ignore the 24th hour so it doesn't get grouped with the current hour.
-    const startTimestamp = Moment().subtract(1, 'day').add(1, 'hour').startOf('hour');
+    const currentDay = template.currentDay.get();
+    if (currentDay) {
+      const startOfDay = Moment(currentDay).startOf('day').toDate(); // Ensure selected day is start of day timestamp.
+      const endOfDay = Moment(currentDay).endOf('day').toDate();
+      const boxEventsSelector = BoxEvents.queryConstructors().getBoxEvents({startTime: startOfDay, endTime: endOfDay});
+      const boxEvents = BoxEvents.find(boxEventsSelector, {sort: {eventEnd: -1}});
 
-    const boxEvents = BoxEvents.find({
-      reqId: {$exists: true},
-      eventEnd: {$gte: startTimestamp.toDate()}
-    }, {
-      sort: {eventEnd: -1}
-    });
-
-    // Calculate labels. Floor of current hour, then get last 23 hours.
-    const currHour = new Date().getHours();
-    const hours = [];
-    for (let i = 0; i < 24; i++) {
-      const hour = currHour - i;
-      (hour < 0) ? hours.push(24 + hour) : hours.push(hour);
-    }
-    hours.reverse(); // Reverse array in-place, so that most recent hour is at the end of the array.
-
-    // Count events. Place into 1 hour groups per deviceId.
-    const eventCountMap = {};
-    boxEvents.forEach(event => {
-      const hour = new Date(event.eventEnd).getHours();
-
-      // Check for deviceId.
-      if (eventCountMap[event.deviceId]) {
-        // Update hour count.
-        (eventCountMap[event.deviceId][hour]) ? eventCountMap[event.deviceId][hour]++ : eventCountMap[event.deviceId][hour] = 1;
-      } else {
-        eventCountMap[event.deviceId] = {[hour]: 1}; // Create new object to keep track of hour count.
+      // Calculate labels. Floor of current hour, then get last 23 hours.
+      const currHour = new Date().getHours();
+      const hours = [];
+      for (let i = 0; i < 24; i++) {
+        const hour = currHour - i;
+        (hour < 0) ? hours.push(24 + hour) : hours.push(hour);
       }
-    });
+      hours.reverse(); // Reverse array in-place, so that most recent hour is at the end of the array.
 
-    // Create dataset
-    const colors = ['rgb(167,197,189)', 'rgb(229,221,203)', 'rgb(235,123,89)', 'rgb(207,70,71)', 'rgb(82,70,86)'];
-    const chartDatasets = [];
-    Object.keys(eventCountMap).forEach(deviceId => {
-      const dataset = {};
-      dataset.label = `Device ${deviceId}`;
-      dataset.backgroundColor = Random.choice(colors);
-      dataset.data = hours.map(hour => eventCountMap[deviceId][hour]);
-      chartDatasets.push(dataset);
-    });
+      // Count events. Place into 1 hour groups per deviceId.
+      const eventCountMap = {};
+      boxEvents.forEach(event => {
+        const hour = new Date(event.eventEnd).getHours();
 
-    console.log(chartDatasets);
-
-    // Create chart
-    const ctx = template.$('#eventCountChart');
-    if (template.eventCountChart) template.eventCountChart.destroy();
-    template.eventCountChart = new Chartjs(ctx, {
-      type: 'bar',
-      data: {
-        labels: hours,
-        datasets: chartDatasets
-      },
-      options: {
-        scales: {
-          xAxes: [{
-            stacked: true,
-            scaleLabel: {
-              display: true,
-              labelString: 'Hour (past 24 hours)'
-            }
-          }],
-          yAxes: [{
-            ticks: {
-              beginAtZero:true
-            },
-            stacked: true,
-            scaleLabel: {
-              display: true,
-              labelString: 'Event Count'
-            }
-          }]
+        // Check for deviceId.
+        if (eventCountMap[event.deviceId]) {
+          // Update hour count.
+          (eventCountMap[event.deviceId][hour]) ? eventCountMap[event.deviceId][hour]++ : eventCountMap[event.deviceId][hour] = 1;
+        } else {
+          eventCountMap[event.deviceId] = {[hour]: 1}; // Create new object to keep track of hour count.
         }
-      }
-    });
+      });
+
+      // Create dataset
+      const colors = ['rgb(167,197,189)', 'rgb(229,221,203)', 'rgb(235,123,89)', 'rgb(207,70,71)', 'rgb(82,70,86)'];
+      const chartDatasets = [];
+      Object.keys(eventCountMap).forEach(deviceId => {
+        const dataset = {};
+        dataset.label = `Device ${deviceId}`;
+        dataset.backgroundColor = Random.choice(colors);
+        dataset.data = hours.map(hour => eventCountMap[deviceId][hour]);
+        chartDatasets.push(dataset);
+      });
+
+      // console.log(chartDatasets);
+
+      // Create chart
+      const ctx = template.$('#eventCountChart');
+      if (template.eventCountChart) template.eventCountChart.destroy();
+      template.eventCountChart = new Chartjs(ctx, {
+        type: 'bar',
+        data: {
+          labels: hours,
+          datasets: chartDatasets
+        },
+        options: {
+          scales: {
+            xAxes: [{
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: 'Hour (past 24 hours)'
+              }
+            }],
+            yAxes: [{
+              ticks: {
+                beginAtZero:true
+              },
+              stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: 'Event Count'
+              }
+            }]
+          }
+        }
+      });
+    }
   });
 });

--- a/view/app/imports/ui/components/filterForm/filterForm.html
+++ b/view/app/imports/ui/components/filterForm/filterForm.html
@@ -3,24 +3,24 @@
     <!--Frequency Range-->
     {{#if frequencyRange}}
       <div class="two fields">
-        {{> Text_Form_Control id="minFrequency" name="minFrequency" label="Min Frequency" rightLabel="Hz"}}
-        {{> Text_Form_Control id="maxFrequency" name="maxFrequency" label="Max Frequency" rightLabel="Hz"}}
+        {{> Text_Form_Control id="minFrequency" name="minFrequency" label="Min Frequency" rightLabel="Hz" errorMessage=(fieldError "minFrequency")}}
+        {{> Text_Form_Control id="maxFrequency" name="maxFrequency" label="Max Frequency" rightLabel="Hz" errorMessage=(fieldError "maxFrequency")}}
       </div>
     {{/if}}
 
     <!--Voltage Range-->
     {{#if voltageRange}}
       <div class="two fields">
-        {{> Text_Form_Control id="minVoltage" name="minVoltage" label="Min Voltage" rightLabel="V"}}
-        {{> Text_Form_Control id="maxVoltage" name="maxVoltage" label="Max Voltage" rightLabel="V"}}
+        {{> Text_Form_Control id="minVoltage" name="minVoltage" label="Min Voltage" rightLabel="V" errorMessage=(fieldError "minVoltage")}}
+        {{> Text_Form_Control id="maxVoltage" name="maxVoltage" label="Max Voltage" rightLabel="V" errorMessage=(fieldError "maxVoltage")}}
       </div>
     {{/if}}
 
     <!--Duration-->
     {{#if durationRange}}
       <div class="two fields">
-        {{> Text_Form_Control id="minDuration" name="minDuration" label="Min Duration" rightLabel="s"}}
-        {{> Text_Form_Control id="maxDuration" name="maxDuration" label="Max Duration" rightLabel="s"}}
+        {{> Text_Form_Control id="minDuration" name="minDuration" label="Min Duration" rightLabel="s" errorMessage=(fieldError "minDuration")}}
+        {{> Text_Form_Control id="maxDuration" name="maxDuration" label="Max Duration" rightLabel="s" errorMessage=(fieldError "maxDuration")}}
       </div>
     {{/if}}
 
@@ -29,14 +29,14 @@
     <!-- Time Inteval -->
     {{#if timeInterval}}
       <div class="two fields">
-        {{> Text_Form_Control id="startTime" name="startTime" label="Start Time" leftIcon="hourglass start"}}
-        {{> Text_Form_Control id="endTime" name="endTime" label="End Time" leftIcon="hourglass end"}}
+        {{> Text_Form_Control id="startTime" name="startTime" label="Start Time" leftIcon="hourglass start" errorMessage=(fieldError "startTime")}}
+        {{> Text_Form_Control id="endTime" name="endTime" label="End Time" leftIcon="hourglass end" errorMessage=(fieldError "endTime")}}
       </div>
     {{/if}}
 
     <!-- Day Picker -->
     {{#if dayPicker}}
-      {{> Text_Form_Control id="dayPicker" name="dayPicker" label="Day Selection" leftIcon="calendar"}}
+      {{> Text_Form_Control id="dayPicker" name="dayPicker" label="Day Selection" leftIcon="calendar" errorMessage=(fieldError "dayPicker")}}
     {{/if}}
 
     <!-- Submit -->

--- a/view/app/imports/ui/components/filterForm/filterForm.html
+++ b/view/app/imports/ui/components/filterForm/filterForm.html
@@ -1,0 +1,45 @@
+<template name="Filter_Form">
+  <form class="ui form filter-form">
+    <!--Frequency Range-->
+    {{#if frequencyRange}}
+      <div class="two fields">
+        {{> Text_Form_Control id="minFrequency" name="minFrequency" label="Min Frequency" rightLabel="Hz"}}
+        {{> Text_Form_Control id="maxFrequency" name="maxFrequency" label="Max Frequency" rightLabel="Hz"}}
+      </div>
+    {{/if}}
+
+    <!--Voltage Range-->
+    {{#if voltageRange}}
+      <div class="two fields">
+        {{> Text_Form_Control id="minVoltage" name="minVoltage" label="Min Voltage" rightLabel="V"}}
+        {{> Text_Form_Control id="maxVoltage" name="maxVoltage" label="Max Voltage" rightLabel="V"}}
+      </div>
+    {{/if}}
+
+    <!--Duration-->
+    {{#if durationRange}}
+      <div class="two fields">
+        {{> Text_Form_Control id="minDuration" name="minDuration" label="Min Duration" rightLabel="s"}}
+        {{> Text_Form_Control id="maxDuration" name="maxDuration" label="Max Duration" rightLabel="s"}}
+      </div>
+    {{/if}}
+
+    <!--ITIC Range-->
+
+    <!-- Time Inteval -->
+    {{#if timeInterval}}
+      <div class="two fields">
+        {{> Text_Form_Control id="startTime" name="startTime" label="Start Time" leftIcon="hourglass start"}}
+        {{> Text_Form_Control id="endTime" name="endTime" label="End Time" leftIcon="hourglass end"}}
+      </div>
+    {{/if}}
+
+    <!-- Day Picker -->
+    {{#if dayPicker}}
+      {{> Text_Form_Control id="dayPicker" name="dayPicker" label="Day Selection" leftIcon="calendar"}}
+    {{/if}}
+
+    <!-- Submit -->
+    <button class="ui button" type="submit">Submit</button>
+  </form>
+</template>

--- a/view/app/imports/ui/components/filterForm/filterForm.js
+++ b/view/app/imports/ui/components/filterForm/filterForm.js
@@ -1,0 +1,134 @@
+import { Template } from 'meteor/templating';
+import { ReactiveVar } from 'meteor/reactive-var';
+import {colorQuantify, dataContextValidator, jQueryPromise} from '../../../utils/utils';
+import './filterForm.html';
+import '../form-controls/text-form-control.html'
+import flatpickr from 'flatpickr';
+import '../../../../node_modules/flatpickr/dist/flatpickr.min.css';
+import { BoxEvents } from '../../../api/boxEvent/BoxEventCollection';
+import Moment from 'moment';
+
+Template.Filter_Form.onCreated(function() {
+  const template = this;
+
+  // Validate data context.
+  dataContextValidator(template, new SimpleSchema({
+    frequencyRange: {type: Boolean, optional: true},
+    voltageRange: {type: Boolean, optional: true},
+    durationRange: {type: Boolean, optional: true},
+    itic: {type: Boolean, optional: true},
+    timeInterval: {type: Boolean, optional: true},
+    dayPicker: {type: Boolean, optional: true},
+    filterSource: {type: ReactiveVar}
+  }), null);
+
+  // Attach data context to template.
+  template.autorun(() => {
+    const dataContext = Template.currentData();
+    template.filterSource = (dataContext.filterSource) ? dataContext.filterSource : null;
+    console.log('filterSource: ', template.filterSource);
+
+  });
+
+  // Form Validation fields
+  //template.validationContext = signupPageSchema.namedContext('Filter_Form');
+  //template.formSubmissionErrors = new ReactiveVar();
+
+  // Holds the timestamp of the beginning of month. Initial value is the current month.
+  template.dayPickerCurrentMonth = new ReactiveVar(Moment().startOf('month').toDate());
+
+  // Subscription
+  template.autorun(() => {
+    const currentMonth = template.dayPickerCurrentMonth.get();
+
+    if (currentMonth) {
+      const endOfMonth = Moment(currentMonth).endOf('month').toDate();
+      console.log('currentMonth: ', currentMonth);
+      console.log('endOfMonth: ', endOfMonth);
+      template.subscribe(BoxEvents.publicationNames.GET_BOX_EVENTS, {startTime: currentMonth, endTime: endOfMonth});
+    }
+
+  });
+
+});
+
+Template.Filter_Form.onRendered(function() {
+  const template = this;
+
+  // Instantiate flatpickr widget, attach to template.
+  template.autorun(() => {
+    const currentMonth = template.dayPickerCurrentMonth.get();
+
+    if (currentMonth && template.subscriptionsReady()) {
+      const flatpickrConfig = {
+        onDayCreate: function(dObj, dStr, fp, dayElem) {
+          const computation = template.autorun(() => {
+            const currDate = dayElem.dateObj;
+            // Ignore the prevMonthDays and nextMonthDays on calendar.
+            if (currDate.getMonth() === fp.currentMonth) {
+              const currentMonth = template.dayPickerCurrentMonth.get();
+              // console.log('cm new: ', fp.currentMonth, currentMonth, Tracker.currentComputation);
+
+              const endOfDay = Moment(currDate).endOf('day').toDate();
+              const selector = BoxEvents.queryConstructors().getBoxEvents({startTime: currDate, endTime: endOfDay});
+              const dailyEventsCount = BoxEvents.find(selector, {}).count();
+
+              if (dailyEventsCount && template.subscriptionsReady()) {
+                const bgColor = colorQuantify(dailyEventsCount, [1, 50], ['#00ff00', '#ffff00', '#ff0000']);
+                $(dayElem).append(`<span class="flatpickr-day-highlight" style="background: ${bgColor};"></span>`);
+              }
+            }
+          });
+
+          (fp.trackerComputations) ? fp.trackerComputations.push(computation) : fp.trackerComputations = [computation];
+        },
+        onMonthChange: function(selectedDates, dateStr, fpInstance) {
+          // Subscribe to month event per day
+          console.log('monthChange');
+          // $('.flatpickr-day.nextMonthDay span.flatpickr-day-highlight').remove();
+          // $('.flatpickr-day.prevMonthDay span.flatpickr-day-highlight').remove();
+          const oldComputations = fpInstance.trackerComputations.splice(0,42);
+          oldComputations.forEach(comp => comp.stop());
+          // console.log('computations: ', fpInstance.trackerComputations);
+          // console.log(selectedDates, dateStr, fpInstance);
+          // Get the Date obj representing start of the current month.
+          const date = Moment().month(fpInstance.currentMonth).year(fpInstance.currentYear).startOf('month').toDate();
+          template.dayPickerCurrentMonth.set(date);
+        }
+      };
+
+      // Only instantiate once.
+      if (!template.dayPicker) template.dayPicker = flatpickr('#dayPicker', flatpickrConfig);
+    }
+  });
+
+});
+
+Template.Filter_Form.events({
+  'submit .filter-form'(event, template) {
+    event.preventDefault();
+    const dataContext = template.data; // Non-reactive
+
+    const formData = {};
+    if (dataContext.frequencyRange) {
+      formData.minFrequency = event.target.minFrequency.value;
+      formData.maxFrequency = event.target.maxFrequency.value;
+    }
+    if (dataContext.voltageRange) {
+      formData.minVoltage = event.target.minVoltage.value;
+      formData.maxVoltage = event.target.maxVoltage.value;
+    }
+    // if (dataContext.durationRange) {
+      formData.minDuration = event.target.minDuration.value;
+      formData.maxDuration = event.target.maxDuration.value;
+    // }
+    if (dataContext.timeInterval) {
+      formData.startTime = event.target.startTime.value;
+      formData.endTime = event.target.endTime.value;
+    }
+
+    console.log('Filter_Form formData submit event: ', formData);
+
+    template.filterSource.set(formData);
+  }
+});

--- a/view/app/imports/ui/components/filterForm/filterForm.js
+++ b/view/app/imports/ui/components/filterForm/filterForm.js
@@ -1,12 +1,14 @@
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
-import {colorQuantify, dataContextValidator, jQueryPromise} from '../../../utils/utils';
+import {colorQuantify, dataContextValidator, jQueryPromise, timeUnitString} from '../../../utils/utils.js';
 import './filterForm.html';
 import '../form-controls/text-form-control.html'
 import flatpickr from 'flatpickr';
 import '../../../../node_modules/flatpickr/dist/flatpickr.min.css';
-import { BoxEvents } from '../../../api/boxEvent/BoxEventCollection';
+import { boxEventsCountMap } from '../../../api/boxEvent/BoxEventCollectionMethods.js';
+import { mapify } from 'es6-mapify';
 import Moment from 'moment';
+import { filterFormSchema } from '../../../utils/schemas.js'
 
 Template.Filter_Form.onCreated(function() {
   const template = this;
@@ -26,81 +28,99 @@ Template.Filter_Form.onCreated(function() {
   template.autorun(() => {
     const dataContext = Template.currentData();
     template.filterSource = (dataContext.filterSource) ? dataContext.filterSource : null;
-    console.log('filterSource: ', template.filterSource);
-
   });
 
-  // Form Validation fields
-  //template.validationContext = signupPageSchema.namedContext('Filter_Form');
-  //template.formSubmissionErrors = new ReactiveVar();
+  // Form Validation Context
+  template.validationContext = filterFormSchema.namedContext('Filter_Form');
 
   // Holds the timestamp of the beginning of month. Initial value is the current month.
   template.dayPickerCurrentMonth = new ReactiveVar(Moment().startOf('month').toDate());
 
-  // Subscription
+  // Holds most recent event count map/dict.
+  template.currentBoxEventsCountMap = new ReactiveVar();
+
+  // When month changes, retrieve event count for that month. This data will be inserted to dayPicker widget.
   template.autorun(() => {
     const currentMonth = template.dayPickerCurrentMonth.get();
-
     if (currentMonth) {
       const endOfMonth = Moment(currentMonth).endOf('month').toDate();
-      console.log('currentMonth: ', currentMonth);
-      console.log('endOfMonth: ', endOfMonth);
-      template.subscribe(BoxEvents.publicationNames.GET_BOX_EVENTS, {startTime: currentMonth, endTime: endOfMonth});
+      boxEventsCountMap.call({timeUnit: 'dayOfMonth', startTime: currentMonth, stopTime: endOfMonth}, (error, eventCountMap) => {
+        if (error) {
+          console.log(error)
+        } else {
+          const ecm = mapify(eventCountMap); // Had to be demapified (aka serialized) before being sent from server.
+          template.currentBoxEventsCountMap.set(ecm);
+        }
+      });
     }
-
   });
 
 });
 
 Template.Filter_Form.onRendered(function() {
   const template = this;
+  const dataContext = template.data;
 
-  // Instantiate flatpickr widget, attach to template.
-  template.autorun(() => {
-    const currentMonth = template.dayPickerCurrentMonth.get();
+  // Instantiate flatpickr for startTime and endTime
+  if (dataContext.timeInterval) {
+    const flatpickrConfig = {
+      enableTime: true,
+      enableSeconds: true
+    };
+    template.startTimeFlatpickr = flatpickr('#startTime', flatpickrConfig);
+    template.endTimeFlatpickr = flatpickr('#endTime', flatpickrConfig);
+  }
 
-    if (currentMonth && template.subscriptionsReady()) {
-      const flatpickrConfig = {
-        onDayCreate: function(dObj, dStr, fp, dayElem) {
-          const computation = template.autorun(() => {
-            const currDate = dayElem.dateObj;
-            // Ignore the prevMonthDays and nextMonthDays on calendar.
-            if (currDate.getMonth() === fp.currentMonth) {
-              const currentMonth = template.dayPickerCurrentMonth.get();
-              // console.log('cm new: ', fp.currentMonth, currentMonth, Tracker.currentComputation);
+  // Instantiate flatpickr widget for dayPicker.
+  // Config here is a bit complicated - but serves as a proof of concept on how to reactively associate data with the
+  // flatpickr widget.
+  if (dataContext.dayPicker) {
+    template.autorun(() => {
+      const currentMonth = template.dayPickerCurrentMonth.get();
+      const eventsCountMap = template.currentBoxEventsCountMap.get();
 
-              const endOfDay = Moment(currDate).endOf('day').toDate();
-              const selector = BoxEvents.queryConstructors().getBoxEvents({startTime: currDate, endTime: endOfDay});
-              const dailyEventsCount = BoxEvents.find(selector, {}).count();
+      if (currentMonth && eventsCountMap && template.subscriptionsReady()) {
+        const flatpickrConfig = {
+          onDayCreate: function(dObj, dStr, fp, dayElem) {
+            const computation = template.autorun(() => {
+              const currDate = dayElem.dateObj;
+              const currMonth = Moment(currDate).month(); // 0-11
+              const timeUnitKey = timeUnitString(currDate, 'dayOfMonth');
 
-              if (dailyEventsCount && template.subscriptionsReady()) {
-                const bgColor = colorQuantify(dailyEventsCount, [1, 50], ['#00ff00', '#ffff00', '#ff0000']);
-                $(dayElem).append(`<span class="flatpickr-day-highlight" style="background: ${bgColor};"></span>`);
+              // Ignore the prevMonthDays and nextMonthDays on calendar.
+              if (currMonth === fp.currentMonth) {
+                const eventsCountMap = template.currentBoxEventsCountMap.get();
+                const eventCount = eventsCountMap.get(timeUnitKey);
+
+                if (eventsCountMap && eventCount && template.subscriptionsReady()) {
+                  $(dayElem).attr('data-tooltip', `${eventCount} events`);
+                  const bgColor = colorQuantify(eventCount, 1, 50, ['#00ff00', '#ffff00', '#ff0000']);
+                  $(dayElem).append(`<span class="flatpickr-day-highlight" style="background: ${bgColor};"></span>`);
+                }
               }
-            }
-          });
+            });
 
-          (fp.trackerComputations) ? fp.trackerComputations.push(computation) : fp.trackerComputations = [computation];
-        },
-        onMonthChange: function(selectedDates, dateStr, fpInstance) {
-          // Subscribe to month event per day
-          console.log('monthChange');
-          // $('.flatpickr-day.nextMonthDay span.flatpickr-day-highlight').remove();
-          // $('.flatpickr-day.prevMonthDay span.flatpickr-day-highlight').remove();
-          const oldComputations = fpInstance.trackerComputations.splice(0,42);
-          oldComputations.forEach(comp => comp.stop());
-          // console.log('computations: ', fpInstance.trackerComputations);
-          // console.log(selectedDates, dateStr, fpInstance);
-          // Get the Date obj representing start of the current month.
-          const date = Moment().month(fpInstance.currentMonth).year(fpInstance.currentYear).startOf('month').toDate();
-          template.dayPickerCurrentMonth.set(date);
-        }
-      };
+            (fp.trackerComputations) ? fp.trackerComputations.push(computation) : fp.trackerComputations = [computation];
+          },
+          onMonthChange: function(selectedDates, dateStr, fpInstance) {
+            // Note: It seems this callback is fired AFTER onDayCreate() when we change month.
 
-      // Only instantiate once.
-      if (!template.dayPicker) template.dayPicker = flatpickr('#dayPicker', flatpickrConfig);
-    }
-  });
+            // Remove old tracker computations. This is important, otherwise we will end up creating a ton of autoruns.
+            const oldComputations = fpInstance.trackerComputations.splice(0,42);
+            oldComputations.forEach(comp => comp.stop());
+
+            // Set RV to new month (which will trigger autorun to method call for new event counts).
+            const date = Moment().month(fpInstance.currentMonth).year(fpInstance.currentYear).startOf('month').toDate();
+            template.dayPickerCurrentMonth.set(date);
+          }
+        };
+
+        // Only instantiate once.
+        if (!template.dayPicker) template.dayPicker = flatpickr('#dayPicker', flatpickrConfig);
+      }
+    });
+  }
+
 
 });
 
@@ -110,25 +130,26 @@ Template.Filter_Form.events({
     const dataContext = template.data; // Non-reactive
 
     const formData = {};
-    if (dataContext.frequencyRange) {
-      formData.minFrequency = event.target.minFrequency.value;
-      formData.maxFrequency = event.target.maxFrequency.value;
-    }
-    if (dataContext.voltageRange) {
-      formData.minVoltage = event.target.minVoltage.value;
-      formData.maxVoltage = event.target.maxVoltage.value;
-    }
-    // if (dataContext.durationRange) {
-      formData.minDuration = event.target.minDuration.value;
-      formData.maxDuration = event.target.maxDuration.value;
-    // }
-    if (dataContext.timeInterval) {
-      formData.startTime = event.target.startTime.value;
-      formData.endTime = event.target.endTime.value;
-    }
+    if (event.target.minFrequency) formData.minFrequency = event.target.minFrequency.value;
+    if (event.target.maxFrequency) formData.maxFrequency = event.target.maxFrequency.value;
 
-    console.log('Filter_Form formData submit event: ', formData);
+    if (event.target.minVoltage) formData.minVoltage = event.target.minVoltage.value;
+    if (event.target.maxVoltage) formData.maxVoltage = event.target.maxVoltage.value;
 
-    template.filterSource.set(formData);
+    if (event.target.minDuration) formData.minDuration = event.target.minDuration.value;
+    if (event.target.maxDuration) formData.maxDuration = event.target.maxDuration.value;
+
+    if (event.target.startTime) formData.startTime = event.target.startTime.value;
+    if (event.target.endTime) formData.endTime = event.target.endTime.value;
+
+    if (event.target.dayPicker) formData.dayPicker = event.target.dayPicker.value;
+
+    // Clean and validate form data.
+    template.validationContext.resetValidation();
+    filterFormSchema.clean(formData);
+    template.validationContext.validate(formData);
+
+    // Set ReactiveVar if valid.
+    if (template.validationContext.isValid()) template.filterSource.set(formData);
   }
 });

--- a/view/app/imports/ui/components/form-controls/input-label-block-helper.html
+++ b/view/app/imports/ui/components/form-controls/input-label-block-helper.html
@@ -1,16 +1,9 @@
 <template name="Input_Label_Block_Helper">
-  {{!
-    This looks pretty convoluted but is necessary because Spacebars does not permit us to open a div inside an #if
-    block without closing the div within the same #if block.
-  }}
-
-
   <div class="ui {{#if leftLabel}}labeled {{/if}}{{#if rightLabel}}right labeled {{/if}}{{#if rightIcon}}icon {{/if}}{{#if leftIcon}}left icon {{/if}}input">
     {{#if leftLabel}}<div class="ui label">{{leftLabel}}</div>{{/if}}
     {{#if leftIcon}}<i class="{{leftIcon}} icon"></i>{{/if}}
     {{> Template.contentBlock}}
     {{#if rightIcon}}<i class="{{rightIcon}} icon"></i>{{/if}}
     {{#if rightLabel}}<div class="ui label">{{rightLabel}}</div>{{/if}}
-
   </div>
 </template>

--- a/view/app/imports/ui/components/form-controls/input-label-block-helper.html
+++ b/view/app/imports/ui/components/form-controls/input-label-block-helper.html
@@ -1,0 +1,16 @@
+<template name="Input_Label_Block_Helper">
+  {{!
+    This looks pretty convoluted but is necessary because Spacebars does not permit us to open a div inside an #if
+    block without closing the div within the same #if block.
+  }}
+
+
+  <div class="ui {{#if leftLabel}}labeled {{/if}}{{#if rightLabel}}right labeled {{/if}}{{#if rightIcon}}icon {{/if}}{{#if leftIcon}}left icon {{/if}}input">
+    {{#if leftLabel}}<div class="ui label">{{leftLabel}}</div>{{/if}}
+    {{#if leftIcon}}<i class="{{leftIcon}} icon"></i>{{/if}}
+    {{> Template.contentBlock}}
+    {{#if rightIcon}}<i class="{{rightIcon}} icon"></i>{{/if}}
+    {{#if rightLabel}}<div class="ui label">{{rightLabel}}</div>{{/if}}
+
+  </div>
+</template>

--- a/view/app/imports/ui/components/form-controls/text-form-control.html
+++ b/view/app/imports/ui/components/form-controls/text-form-control.html
@@ -3,20 +3,24 @@
     Implements a Semantic-UI styled text field.
 
     Params:
-      id, name, label, value, errorMessage (String)
+      id, name, label, value, errorMessage, leftLabel, rightLabel, leftIcon, rightIcon (String)
       isRequired, isInline, isPasswordField (Boolean)
 
     Label is required.
     Id, name, and placeholder default to label, but these should generally be given an explicit value.
   }}
 
-  <div class="{{#if isRequired}}required{{/if}} {{#if isInline}}inline{{/if}} {{#if errorMessage}}error{{/if}} field">
+  <div class="{{#if isRequired}}required{{/if}}{{#if isInline}}inline{{/if}}{{#if errorMessage}}error{{/if}} field">
+
     <label>{{label}}</label>
-    <input type="{{#if isPasswordField}}password{{else}}text{{/if}}"
-           name="{{#if name}}{{name}}{{else}}{{label}}{{/if}}"
-           id="{{#if id}}{{id}}{{else}}{{label}}{{/if}}"
-           placeholder="{{#if placeholder}}{{placeholder}}{{else}}{{label}}{{/if}}"
-           value="{{value}}">
+
+    {{#Input_Label_Block_Helper leftLabel=leftLabel rightLabel=rightLabel leftIcon=leftIcon rightIcon=rightIcon}}
+      <input type="{{#if isPasswordField}}password{{else}}text{{/if}}"
+             name="{{#if name}}{{name}}{{else}}{{label}}{{/if}}"
+             id="{{#if id}}{{id}}{{else}}{{label}}{{/if}}"
+             placeholder="{{#if placeholder}}{{placeholder}}{{else}}{{label}}{{/if}}"
+             value="{{value}}">
+    {{/Input_Label_Block_Helper}}
 
     {{#if errorMessage}}
       <div class="ui pointing label">

--- a/view/app/imports/ui/components/form-controls/text-form-control.html
+++ b/view/app/imports/ui/components/form-controls/text-form-control.html
@@ -3,14 +3,35 @@
     Implements a Semantic-UI styled text field.
 
     Params:
-      id, name, label, value, errorMessage, leftLabel, rightLabel, leftIcon, rightIcon (String)
+      id, name, label, value, errorMessage, leftLabel, rightLabel, leftIcon, rightIcon, gridWidth (String)
       isRequired, isInline, isPasswordField (Boolean)
 
     Label is required.
     Id, name, and placeholder default to label, but these should generally be given an explicit value.
+
+    Note on inline fields: Semantic-UI gives inline fields a default width that is quite small. Due to the way SUI
+    works, in order to specify a width for inline fields, you will need to wrap this template with an "inline fields"
+    div, and then explicitly specifying a gridWidth for each individual field. The isInline parameter is only needed
+    for the case where you want the default (tiny) width individual field (which you probably don't).
+
+    Inline fields have a default width that is quite small. As such, they should almost always be given a gridWidth.
+    Non-inline fields have a default width of 100% its container. This is just due to how SUI works. Non-inline fields
+    can also be given a specific gridWidth if needed.
+
+    E.g. Full width single inline field:
+    <div class="inline fields">
+      {> Text_Form_Control label="Hello World" gridWidth="sixteen"} (double brackets omitted due to comment notation)
+    </div>
+
+    E.g. Three inline fields in a group:
+    <div class="inline fields">
+      {> Text_Form_Control label="First Name" gridWidth="six"}
+      {> Text_Form_Control label="Middle Name" gridWidth="three"}
+      {> Text_Form_Control label="Last Name" gridWidth="seven"}
+    </div>
   }}
 
-  <div class="{{#if isRequired}}required{{/if}}{{#if isInline}}inline{{/if}}{{#if errorMessage}}error{{/if}} field">
+  <div class="{{#if isRequired}}required{{/if}}{{#if isInline}} inline{{/if}}{{#if errorMessage}} error{{/if}}{{#if gridWidth}} {{gridWidth}} wide{{/if}} field">
 
     <label>{{label}}</label>
 

--- a/view/app/imports/ui/pages/research/research.html
+++ b/view/app/imports/ui/pages/research/research.html
@@ -73,12 +73,21 @@
 
       <div class="eight wide column">
         <div class="ui top attached segment">
-          <h3 class="ui header">
-            Event Count
-          </h3>
+          <button id="eventCountChartFiltersButton" class="ui right floated icon basic button" style="margin-top: -6px;">
+            <i class="filter icon"></i> Filters
+          </button>
+          <div class="content">
+            <h3 class="ui header">Event Count</h3>
+          </div>
         </div>
         <div class="ui bottom attached segment">
-          {{> eventCountChart}}
+          {{> eventCountChart filters=(dataSink "eventCountChartFilters")}}
+        </div>
+      </div>
+
+      <div id="eventCountChartFiltersPopup" class="ui popup">
+        <div style="width: 200px;">
+          {{> Filter_Form dayPicker=true filterSource=(dataSource "eventCountChartFilters")}}
         </div>
       </div>
 

--- a/view/app/imports/ui/pages/research/research.js
+++ b/view/app/imports/ui/pages/research/research.js
@@ -11,7 +11,7 @@ import Chartjs from 'chart.js';
 import './research.html';
 import '../../components/liveMeasurements/liveMeasurements.js';
 import '../../components/eventCountChart/eventCountChart.js';
-
+import '../../components/filterForm/filterForm.js';
 
 
 Template.research.onCreated(function() {
@@ -173,7 +173,25 @@ Template.research.onCreated(function() {
 Template.research.onRendered(function() {
   const template = this;
 
-  template.$('.ui.checkbox').checkbox(); // Enable Semantic-UI toggle styled checkbox.
+  // Enable Semantic-UI toggle styled checkbox.
+  template.$('.ui.checkbox').checkbox();
+
+  // Setup filter form popup
+  template.$('#eventCountChartFiltersButton').popup({
+    popup : template.$('#eventCountChartFiltersPopup'),
+    on: 'click',
+    position: 'bottom right',
+    lastResort: true,
+    closable: false, // Need this because popup is closing on flatpickr usage.
+    onShow: function() {
+      //template.showPopup.set(true);
+      console.log('showing');
+    },
+    onHide: function() {
+      //template.showPopup.set(false);
+      console.log('hiding');
+    }
+  });
 
   // Plots waveform whenever an event is selected.
   template.autorun(function() {

--- a/view/app/imports/ui/stylesheets/site.css
+++ b/view/app/imports/ui/stylesheets/site.css
@@ -386,3 +386,14 @@ we'll still call it expanded for naming consistency and simplicity.
 .float-right {
     float: right !important;
 }
+
+.flatpickr-day-highlight {
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-radius: 150px;
+    bottom: 3px;
+    left: calc(50% - 3px);
+    content: " ";
+    display: block;
+}

--- a/view/app/imports/utils/schemas.js
+++ b/view/app/imports/utils/schemas.js
@@ -228,3 +228,15 @@ Global.Schemas.UserSettings = new SimpleSchema([
 //     }
 //   }
 // ]);
+
+export const filterFormSchema = new SimpleSchema({
+  minFrequency: {type: Number, optional: true},
+  maxFrequency: {type: Number, optional: true},
+  minVoltage: {type: Number, optional: true},
+  maxVoltage: {type: Number, optional: true},
+  minDuration: {type: Number, optional: true},
+  maxDuration: {type: Number, optional: true},
+  startTime: {type: String, optional: true},
+  endTime: {type: String, optional: true},
+  dayPicker: {type: String, optional: true}
+});

--- a/view/app/imports/utils/utils.js
+++ b/view/app/imports/utils/utils.js
@@ -66,7 +66,6 @@ export const dataContextValidator = (templateInstance, baseSchema, nestedReactiv
     if (dataContext) {
       // Validate against base schema.
       baseSchema.validate(dataContext);
-      console.log('BaseSchema validated');
 
       /**
        * Validate all given ReactiveVar schemas with their respective data context objects. ReactiveVar values are
@@ -98,14 +97,12 @@ export const dataContextValidator = (templateInstance, baseSchema, nestedReactiv
             new SimpleSchema({
               _singleKeySchema: currentSchema // currentSchema, in this case, just holds the schema rules object. See above.
             }).validate({_singleKeySchema: reactiveValue});
-            console.log('single validation');
           } else {
             // Otherwise we have the 'normal' case where we can simply validate against the ReactiveVar's value.
             currentSchema.validate(reactiveValue);
-            console.log('regular validation');
           }
 
-          console.log(`${schemaKey} schema validated`);
+          // console.log(`${schemaKey} schema validated`);
         });
       }
     }

--- a/view/app/imports/utils/utils.js
+++ b/view/app/imports/utils/utils.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Template } from 'meteor/templating';
+import Moment from 'moment';
 
 /**
  * Experimental function utilizing a Promise object that will eventually return a jQuery object matching the requested
@@ -137,4 +138,84 @@ export const getRootTemplateInstance = (templateOrView) => {
   }
 
   return topMostView.templateInstance();
+};
+
+/**
+ * Calculates the appropriate color representation of a numeric value. Evaluated on a linear scale.
+ * @param {Number} dataValue - The value to evaluate a color for.
+ * @param {Number} minValue - The minimum value to be represented with the first color in the colorRange array.
+ * @param {Number} maxValue - The maximum value to be represented with the last color in the colorRange array.
+ * @param {String[]} colorRange - An array of hex colors, ordered from least to greatest intended color value.
+ * @returns {String} - The calculated hex color representation of the given value.
+ */
+export const colorQuantify = (dataValue, minValue, maxValue, colorRange) => {
+  check(dataValue, Number);
+  check(minValue, Number);
+  check(maxValue, Number);
+  check(colorRange, [String]);
+
+  // DomainDifference / NumColors
+  // Gives us the value that evenly splits up the dataDomain based on the given number of colors.
+  const dataDomainIncrement = Math.abs(maxValue - minValue) / colorRange.length;
+
+  let resultColor = null;
+  for (let i = 0; i < colorRange.length; i++) {
+    if (dataValue < minValue + (dataDomainIncrement * (i+1))) {
+      resultColor = colorRange[i];
+      break;
+    }
+  }
+
+  // Takes care of case where dataValue is larger than maxValue (chooses the last color). Note that the above loop
+  // will take care of the case where dataValue is smaller than minValue (chooses the first color)
+  if (!resultColor) resultColor = colorRange[colorRange.length-1];
+
+  return resultColor;
+};
+
+/**
+ * Returns a unique string representation of the given date 'rounded' to the desired unit of time.
+ * @param {Date} date - The date object to evaluate.
+ * @param timeUnit - The unit of time to round to. Allowed values: 'year', 'month', 'week', 'day', 'dayOfMonth', 'hourOfDay'
+ * @returns {String} - The appropriate string value of the given Date, based on the given unit of time.
+ */
+export const timeUnitString = (date, timeUnit) => {
+  const mDate = Moment(date);
+  const hour = mDate.hour(); // 0-23
+  const dayOfMonth = mDate.date(); // 1-31
+  const day = mDate.dayOfYear(); // 1-366
+  const week = mDate.week(); // 1-52
+  const month = mDate.month(); // 0-11
+  const year = mDate.year(); // 4 digit year
+
+  // All keys are appended with year to ensure uniqueness of key (in case we're given a long time range).
+  let timeUnitKey;
+  switch(timeUnit) {
+    case 'hourOfDay':
+      // Hour of day. Format: hour-day-year. E.g. 23-365-2014, 4-125-1999, etc.
+      timeUnitKey = `${hour}-${day}-${year}`;
+      break;
+    case 'dayOfMonth':
+      // Day of month. Format: dayOfMonth-month-year. E.g. 28-11-2008, 31-4-2012, etc.
+      timeUnitKey = `${dayOfMonth}-${month}-${year}`;
+      break;
+    case 'day':
+      // Day of year. Format: dayOfYear-year. E.g. 365-2002, 147-1945, etc.
+      timeUnitKey = `${day}-${year}`;
+      break;
+    case 'week':
+      // Week of year. Format: week-year. E.g. 51-2006, 4-1998, etc.
+      timeUnitKey = `${week}-${year}`;
+      break;
+    case 'month':
+      // Month of year. Format: month-year. E.g. 2-1988, 11-2014, etc.
+      timeUnitKey = `${month}-${year}`;
+      break;
+    case 'year':
+      // 4 digit year. Format: year. E.g. 1945, 1999, 2017, etc.
+      timeUnitKey = year;
+      break;
+  }
+
+  return timeUnitKey;
 };

--- a/view/app/imports/utils/utils.js
+++ b/view/app/imports/utils/utils.js
@@ -110,3 +110,31 @@ export const dataContextValidator = (templateInstance, baseSchema, nestedReactiv
     }
   });
 };
+
+/**
+ * Given a template instance or view, finds and returns the top-most/root template instance by traversing up
+ * the view tree.
+ * @param {(Blaze.TemplateInstance|Blaze.View)} templateOrView - The TemplateInstance or Blaze View to find the root template of.
+ * @returns {Blaze.TemplateInstance} - The root template instance.
+ */
+export const getRootTemplateInstance = (templateOrView) => {
+  let currentView = null;
+  if (templateOrView instanceof Blaze.View) {
+    currentView = templateOrView;
+  } else if (templateOrView instanceof Blaze.TemplateInstance) {
+    currentView = templateOrView.view; // Get its corresponding view
+  } else {
+    throw new Meteor.Error('Invalid arguments - Must be of type TemplateInstance or View');
+  }
+
+  // Find root template
+  let topMostView = null;
+  while (currentView) {
+    // Not all Views we are traversing will have a template associated with it - the ones that do have a template
+    // property associated with it.
+    if (currentView.template) topMostView = currentView;
+    currentView = currentView.parentView;
+  }
+
+  return topMostView.templateInstance();
+};


### PR DESCRIPTION
Implemented a versatile filterForm template that can be customized to display any relevant fields the user might wish to filter their data by. The filterForm template can be easily attached to other component templates by using the newly implemented dataSource and dataSink global helpers.

Also of note: We now attach an _isRendered ReactiveVar to each template upon creation, which gives us a way now to reactively detect when any given template has been rendered. This was easily implemented using the aldeed:template-extensions package.