### PR TITLE
Issue 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 .idea/
 *.iml
 .DS_Store
-settings.production.json
+settings-production.*
 node_modules
 _book

--- a/view/app/imports/api/boxEvent/BoxEventCollection.js
+++ b/view/app/imports/api/boxEvent/BoxEventCollection.js
@@ -18,7 +18,7 @@ class BoxEventCollection extends BaseCollection {
           percent: {type: Number},
           reqId: {type: Number}
         }),
-        'mongodb://localhost:3002/opq'
+        Meteor.settings.opqRemoteMongoUrl
     );
 
     this.publicationNames = {

--- a/view/app/imports/api/eventData/EventDataCollection.js
+++ b/view/app/imports/api/eventData/EventDataCollection.js
@@ -21,7 +21,7 @@ class EventDataCollection extends BaseCollection {
           //data: {type: [Number]} // These values need to be divided by device calibration constant.
           data: {type: String} // Stores the GridFs filename. Format is 'event_eventNumber_boxId'
         }),
-        'mongodb://localhost:3002/opq'
+        Meteor.settings.opqRemoteMongoUrl
     );
 
     this.publicationNames = {

--- a/view/app/imports/api/eventDataFS/EventDataFSCollection.js
+++ b/view/app/imports/api/eventDataFS/EventDataFSCollection.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
-export const EventDataFSFiles = (Meteor.isServer) ? new Mongo.Collection('fs.files', {idGeneration: 'MONGO', _driver: new MongoInternals.RemoteCollectionDriver('mongodb://localhost:3002/opq')})
+export const EventDataFSFiles = (Meteor.isServer) ? new Mongo.Collection('fs.files', {idGeneration: 'MONGO', _driver: new MongoInternals.RemoteCollectionDriver(Meteor.settings.opqRemoteMongoUrl)})
                                                   : new Mongo.Collection('fs.files', {idGeneration: 'MONGO'});
 
-export const EventDataFSChunks = (Meteor.isServer) ? new Mongo.Collection('fs.chunks', {idGeneration: 'MONGO', _driver: new MongoInternals.RemoteCollectionDriver('mongodb://localhost:3002/opq')})
+export const EventDataFSChunks = (Meteor.isServer) ? new Mongo.Collection('fs.chunks', {idGeneration: 'MONGO', _driver: new MongoInternals.RemoteCollectionDriver(Meteor.settings.opqRemoteMongoUrl)})
                                                    : new Mongo.Collection('fs.chunks', {idGeneration: 'MONGO'});

--- a/view/app/imports/api/eventMetaData/EventMetaDataCollection.js
+++ b/view/app/imports/api/eventMetaData/EventMetaDataCollection.js
@@ -23,7 +23,7 @@ class EventMetaDataCollection extends BaseCollection {
           event_end: {type: Number},
           time_stamp: {type: [Number]} // For research data; OpqView can ignore this.
         }),
-        'mongodb://localhost:3002/opq'
+        Meteor.settings.opqRemoteMongoUrl
     );
 
     this.publicationNames = {

--- a/view/app/imports/api/measurement/MeasurementCollection.js
+++ b/view/app/imports/api/measurement/MeasurementCollection.js
@@ -15,7 +15,7 @@ class MeasurementCollection extends BaseCollection {
           voltage: {type: Number},
           frequency: {type: Number}
         }),
-        'mongodb://localhost:3002/opq'
+        Meteor.settings.opqRemoteMongoUrl
     );
 
     this.publicationNames = {

--- a/view/app/package.json
+++ b/view/app/package.json
@@ -31,6 +31,7 @@
     }
   },
   "scripts": {
+    "start": "meteor --settings ../config/settings-development.json",
     "test": "meteor test --once --driver-package dispatch:mocha",
     "jsdoc": "./node_modules/.bin/jsdoc -c ./jsdoc.json -r ."
   },

--- a/view/config/settings-development.json
+++ b/view/config/settings-development.json
@@ -1,0 +1,6 @@
+{
+	"public": {
+
+	},
+	"opqRemoteMongoUrl": "mongodb://localhost:3002/opq"
+}


### PR DESCRIPTION
- Event waveforms are now synchronized properly between boxes
- Created a development-only configuration file (settings-development.json) for secret keys and other variables. A production-only version of this file (settings-production.json) must be used on production (which contains the actual secret information). Gitignore has been updated as needed to reflect these additions.
- Created an npm startup script to load the aforementioned config file with Meteor